### PR TITLE
Print an error message if no target node is defined

### DIFF
--- a/addons/smoothing/smoothing.gd
+++ b/addons/smoothing/smoothing.gd
@@ -44,23 +44,23 @@ export (int, FLAGS, "enabled", "translate", "basis", "slerp") var flags : int = 
 func teleport():
 	var temp_flags = flags
 	_SetFlags(SF_TRANSLATE | SF_BASIS)
-	
+
 	_RefreshTransform()
 	_m_trPrev = _m_trCurr
-	
+
 	# do one frame update to make sure all components are updated
 	_process(0)
-	
+
 	# resume old flags
 	flags = temp_flags
-	
+
 func set_enabled(var bEnable : bool):
 	_ChangeFlags(SF_ENABLED, bEnable)
 	_SetProcessing()
 
 func is_enabled():
 	return _TestFlags(SF_ENABLED)
-	
+
 
 
 
@@ -71,20 +71,22 @@ func _ready():
 	_m_trCurr = Transform()
 	_m_trPrev = Transform()
 
+	if _m_Target == null:
+		push_error("A target must be defined for the Smoothing node to work.")
 
 func set_target(new_value):
 	target = new_value
 	if is_inside_tree():
 		_FindTarget()
-	
+
 func get_target():
 	return target
-	
+
 func _set_flags(new_value):
 	flags = new_value
 	# we may have enabled or disabled
 	_SetProcessing()
-	
+
 func _get_flags():
 	return flags
 
@@ -108,41 +110,41 @@ func _notification(what):
 		NOTIFICATION_VISIBILITY_CHANGED:
 			_ChangeFlags(SF_INVISIBLE, is_visible_in_tree() == false)
 			_SetProcessing()
-			
-		
+
+
 
 func _RefreshTransform():
 	_ClearFlags(SF_DIRTY);
-	
+
 	if _HasTarget() == false:
 		return
-	
+
 	_m_trPrev = _m_trCurr
 	_m_trCurr = _m_Target.transform
-	
+
 
 func _FindTarget():
 	_m_Target = null
 	if target.is_empty():
 		return
-		
+
 	_m_Target = get_node(target)
-	
+
 	if _m_Target is Spatial:
 		return
 
 	_m_Target = null
 	#return false
-	
+
 
 func _HasTarget()->bool:
 	if _m_Target == null:
 		return false
-	
+
 	# has not been deleted?
 	if is_instance_valid(_m_Target):
 		return true
-		
+
 	_m_Target = null
 	return false
 
@@ -150,9 +152,9 @@ func _HasTarget()->bool:
 func _process(_delta):
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	var f = Engine.get_physics_interpolation_fraction()
-	
+
 	var tr : Transform = Transform()
 
 	# translate
@@ -168,15 +170,15 @@ func _process(_delta):
 			tr.basis = _LerpBasis(_m_trPrev.basis, _m_trCurr.basis, f)
 
 	transform = tr
-	
+
 	pass
-	
+
 func _physics_process(_delta):
 	# take care of the special case where multiple physics ticks
 	# occur before a frame .. the data must flow!
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	_SetFlags(SF_DIRTY)
 	pass
 
@@ -189,10 +191,10 @@ func _LerpBasis(var from : Basis, var to : Basis, var f : float)->Basis:
 
 func _SetFlags(var f):
 	flags |= f
-	
+
 func _ClearFlags(var f):
 	flags &= ~f
-	
+
 func _TestFlags(var f):
 	return (flags & f) == f
 

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -52,7 +52,7 @@ export (int, FLAGS, "enabled", "translate", "rotate", "scale", "global in", "glo
 func teleport():
 	var temp_flags = flags
 	_SetFlags(SF_TRANSLATE | SF_ROTATE | SF_SCALE)
-	
+
 	_RefreshTransform()
 	m_Pos_prev = m_Pos_curr
 	m_Angle_prev = m_Angle_curr
@@ -63,14 +63,14 @@ func teleport():
 
 	# get back the old flags
 	flags = temp_flags
-	
+
 func set_enabled(var bEnable : bool):
 	_ChangeFlags(SF_ENABLED, bEnable)
 	_SetProcessing()
 
 func is_enabled():
 	return _TestFlags(SF_ENABLED)
-	
+
 
 
 
@@ -80,13 +80,15 @@ func is_enabled():
 func _ready():
 	m_Angle_curr = 0
 	m_Angle_prev = 0
-	pass
+
+	if _m_Target == null:
+		push_error("A target must be defined for the Smoothing2D node to work.")
 
 func set_target(new_value):
 	target = new_value
 	if is_inside_tree():
 		_FindTarget()
-	
+
 func get_target():
 	return target
 
@@ -94,7 +96,7 @@ func _set_flags(new_value):
 	flags = new_value
 	# we may have enabled or disabled
 	_SetProcessing()
-	
+
 func _get_flags():
 	return flags
 
@@ -118,24 +120,24 @@ func _notification(what):
 		NOTIFICATION_VISIBILITY_CHANGED:
 			_ChangeFlags(SF_INVISIBLE, is_visible_in_tree() == false)
 			_SetProcessing()
-			
-		
+
+
 
 func _RefreshTransform():
 	_ClearFlags(SF_DIRTY);
-	
+
 	if _HasTarget() == false:
 		return
-	
+
 	if _TestFlags(SF_GLOBAL_IN):
 		if _TestFlags(SF_TRANSLATE):
 			m_Pos_prev = m_Pos_curr
 			m_Pos_curr = _m_Target.get_global_position()
-			
+
 		if _TestFlags(SF_ROTATE):
 			m_Angle_prev = m_Angle_curr
 			m_Angle_curr = _m_Target.get_global_rotation()
-			
+
 		if _TestFlags(SF_SCALE):
 			m_Scale_prev = m_Scale_curr
 			m_Scale_curr = _m_Target.get_global_scale()
@@ -143,37 +145,37 @@ func _RefreshTransform():
 		if _TestFlags(SF_TRANSLATE):
 			m_Pos_prev = m_Pos_curr
 			m_Pos_curr = _m_Target.get_position()
-			
+
 		if _TestFlags(SF_ROTATE):
 			m_Angle_prev = m_Angle_curr
 			m_Angle_curr = _m_Target.get_rotation()
-			
+
 		if _TestFlags(SF_SCALE):
 			m_Scale_prev = m_Scale_curr
 			m_Scale_curr = _m_Target.get_scale()
-	
-	
+
+
 func _FindTarget():
 	_m_Target = null
 	if target.is_empty():
 		return
-		
+
 	_m_Target = get_node(target)
-	
+
 	if _m_Target is Node2D:
 		return
 
 	_m_Target = null
-	
+
 
 func _HasTarget()->bool:
 	if _m_Target == null:
 		return false
-	
+
 	# has not been deleted?
 	if is_instance_valid(_m_Target):
 		return true
-		
+
 	_m_Target = null
 	return false
 
@@ -181,43 +183,43 @@ func _HasTarget()->bool:
 func _process(_delta):
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	var f = Engine.get_physics_interpolation_fraction()
-	
+
 
 	if _TestFlags(SF_GLOBAL_OUT):
 		# translate
 		if _TestFlags(SF_TRANSLATE):
 			set_global_position(m_Pos_prev.linear_interpolate(m_Pos_curr, f))
-	
+
 		# rotate
 		if _TestFlags(SF_ROTATE):
 			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
 			set_global_rotation(r)
-	
+
 		if _TestFlags(SF_SCALE):
 			set_global_scale(m_Scale_prev.linear_interpolate(m_Scale_curr, f))
 	else:
 		# translate
 		if _TestFlags(SF_TRANSLATE):
 			set_position(m_Pos_prev.linear_interpolate(m_Pos_curr, f))
-	
+
 		# rotate
 		if _TestFlags(SF_ROTATE):
 			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
 			set_rotation(r)
-	
+
 		if _TestFlags(SF_SCALE):
 			set_scale(m_Scale_prev.linear_interpolate(m_Scale_curr, f))
-	
+
 	pass
-	
+
 func _physics_process(_delta):
 	# take care of the special case where multiple physics ticks
 	# occur before a frame .. the data must flow!
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	_SetFlags(SF_DIRTY)
 	pass
 
@@ -231,10 +233,10 @@ func _ShortAngleDist(var from : float, var to : float)->float:
 
 func _SetFlags(var f):
 	flags |= f
-	
+
 func _ClearFlags(var f):
 	flags &= ~f
-	
+
 func _TestFlags(var f):
 	return (flags & f) == f
 


### PR DESCRIPTION
This also removes trailing whitespace.