### PR TITLE
Use `assert()` to check whether a target node is defined

### DIFF
--- a/addons/smoothing/smoothing.gd
+++ b/addons/smoothing/smoothing.gd
@@ -71,8 +71,7 @@ func _ready():
 	_m_trCurr = Transform()
 	_m_trPrev = Transform()
 
-	if _m_Target == null:
-		push_error("A target must be defined for the Smoothing node to work.")
+	assert(_m_Target != null, "A target must be defined for the Smoothing node to work.")
 
 func set_target(new_value):
 	target = new_value

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -81,8 +81,7 @@ func _ready():
 	m_Angle_curr = 0
 	m_Angle_prev = 0
 
-	if _m_Target == null:
-		push_error("A target must be defined for the Smoothing2D node to work.")
+	assert(_m_Target != null, "A target must be defined for the Smoothing2D node to work.")
 
 func set_target(new_value):
 	target = new_value


### PR DESCRIPTION
This makes the editor pause if the condition isn't met, instead of just printing an error message in the output log. Since defining a target node is absolutely required for the add-on to work, it makes sense to pause the editor in this case.

A message can still be displayed thanks to Godot 3.2's custom assert messages feature.