### PR TITLE
Format code using `gdformat -l 999 **/*.gd`

### DIFF
--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -20,18 +20,18 @@
 
 extends Node2D
 
-export(NodePath) var target : NodePath setget set_target, get_target
+export (NodePath) var target: NodePath setget set_target, get_target
 
-var _m_Target : Node2D
+var _m_Target: Node2D
 
-var m_Pos_curr : Vector2 = Vector2()
-var m_Pos_prev : Vector2 = Vector2()
+var m_Pos_curr: Vector2 = Vector2()
+var m_Pos_prev: Vector2 = Vector2()
 
-var m_Angle_curr : float
-var m_Angle_prev : float
+var m_Angle_curr: float
+var m_Angle_prev: float
 
-var m_Scale_curr : Vector2 = Vector2()
-var m_Scale_prev : Vector2 = Vector2()
+var m_Scale_curr: Vector2 = Vector2()
+var m_Scale_prev: Vector2 = Vector2()
 
 const SF_ENABLED = 1 << 0
 const SF_TRANSLATE = 1 << 1
@@ -42,17 +42,18 @@ const SF_GLOBAL_OUT = 1 << 5
 const SF_DIRTY = 1 << 6
 const SF_INVISIBLE = 1 << 7
 
-export (int, FLAGS, "enabled", "translate", "rotate", "scale", "global in", "global out") var flags : int = SF_ENABLED | SF_TRANSLATE setget _set_flags, _get_flags
+export (int, FLAGS, "enabled", "translate", "rotate", "scale", "global in", "global out") var flags: int = SF_ENABLED | SF_TRANSLATE setget _set_flags, _get_flags
 
 ##########################################################################################
 # USER FUNCS
+
 
 # call this on e.g. starting a level, AFTER moving the target
 # so we can update both the previous and current values
 func teleport():
 	var temp_flags = flags
 	_SetFlags(SF_TRANSLATE | SF_ROTATE | SF_SCALE)
-	
+
 	_RefreshTransform()
 	m_Pos_prev = m_Pos_curr
 	m_Angle_prev = m_Angle_curr
@@ -63,15 +64,15 @@ func teleport():
 
 	# get back the old flags
 	flags = temp_flags
-	
-func set_enabled(var bEnable : bool):
+
+
+func set_enabled(bEnable: bool):
 	_ChangeFlags(SF_ENABLED, bEnable)
 	_SetProcessing()
 
+
 func is_enabled():
 	return _TestFlags(SF_ENABLED)
-	
-
 
 
 ##########################################################################################
@@ -82,35 +83,42 @@ func _ready():
 	m_Angle_prev = 0
 	pass
 
+
 func set_target(new_value):
 	target = new_value
 	if is_inside_tree():
 		_FindTarget()
-	
+
+
 func get_target():
 	return target
+
 
 func _set_flags(new_value):
 	flags = new_value
 	# we may have enabled or disabled
 	_SetProcessing()
-	
+
+
 func _get_flags():
 	return flags
+
 
 func _SetProcessing():
 	var bEnable = _TestFlags(SF_ENABLED)
 	if _TestFlags(SF_INVISIBLE):
 		bEnable = false
 
-	set_process(bEnable);
-	set_physics_process(bEnable);
+	set_process(bEnable)
+	set_physics_process(bEnable)
 	pass
+
 
 func _enter_tree():
 	# might have been moved
 	_FindTarget()
 	pass
+
 
 func _notification(what):
 	match what:
@@ -118,24 +126,23 @@ func _notification(what):
 		NOTIFICATION_VISIBILITY_CHANGED:
 			_ChangeFlags(SF_INVISIBLE, is_visible_in_tree() == false)
 			_SetProcessing()
-			
-		
+
 
 func _RefreshTransform():
-	_ClearFlags(SF_DIRTY);
-	
+	_ClearFlags(SF_DIRTY)
+
 	if _HasTarget() == false:
 		return
-	
+
 	if _TestFlags(SF_GLOBAL_IN):
 		if _TestFlags(SF_TRANSLATE):
 			m_Pos_prev = m_Pos_curr
 			m_Pos_curr = _m_Target.get_global_position()
-			
+
 		if _TestFlags(SF_ROTATE):
 			m_Angle_prev = m_Angle_curr
 			m_Angle_curr = _m_Target.get_global_rotation()
-			
+
 		if _TestFlags(SF_SCALE):
 			m_Scale_prev = m_Scale_curr
 			m_Scale_curr = _m_Target.get_global_scale()
@@ -143,25 +150,27 @@ func _RefreshTransform():
 		if _TestFlags(SF_TRANSLATE):
 			m_Pos_prev = m_Pos_curr
 			m_Pos_curr = _m_Target.get_position()
-			
+
 		if _TestFlags(SF_ROTATE):
 			m_Angle_prev = m_Angle_curr
 			m_Angle_curr = _m_Target.get_rotation()
-			
+
 		if _TestFlags(SF_SCALE):
 			m_Scale_prev = m_Scale_curr
 			m_Scale_curr = _m_Target.get_scale()
-	
-func _IsTargetParent(var node):
+
+
+func _IsTargetParent(node):
 	if node == _m_Target:
-		return true # disallow
-	
+		return true  # disallow
+
 	var parent = node.get_parent()
 	if parent:
 		return _IsTargetParent(parent)
-	
+
 	return false
-	
+
+
 func _FindTarget():
 	_m_Target = null
 	if target.is_empty():
@@ -169,15 +178,15 @@ func _FindTarget():
 
 	var targ = get_node(target)
 
-	if !targ:
+	if ! targ:
 		printerr("ERROR SmoothingNode2D : Target " + target + " not found")
 		return
-	
+
 	if not targ is Node2D:
 		printerr("ERROR SmoothingNode2D : Target " + target + " is not Node2D")
 		target = ""
 		return
-		
+
 	# if we got to here targ is correct type
 	_m_Target = targ
 
@@ -187,6 +196,8 @@ func _FindTarget():
 	# do a final check
 	# is the target a parent or grandparent of the smoothing node?
 	# if so, disallow
+
+
 #	if _IsTargetParent(self):
 #		var msg = _m_Target.get_name() + " assigned to " + self.get_name() + "]"
 #		printerr("ERROR SmoothingNode2D : Target should not be a parent or grandparent [", msg)
@@ -196,14 +207,15 @@ func _FindTarget():
 #		target = ""
 #		return
 
-func _HasTarget()->bool:
+
+func _HasTarget() -> bool:
 	if _m_Target == null:
 		return false
-	
+
 	# has not been deleted?
 	if is_instance_valid(_m_Target):
 		return true
-		
+
 	_m_Target = null
 	return false
 
@@ -211,64 +223,70 @@ func _HasTarget()->bool:
 func _process(_delta):
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	var f = Engine.get_physics_interpolation_fraction()
-	
 
 	if _TestFlags(SF_GLOBAL_OUT):
 		# translate
 		if _TestFlags(SF_TRANSLATE):
 			set_global_position(m_Pos_prev.linear_interpolate(m_Pos_curr, f))
-	
+
 		# rotate
 		if _TestFlags(SF_ROTATE):
 			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
 			set_global_rotation(r)
-	
+
 		if _TestFlags(SF_SCALE):
 			set_global_scale(m_Scale_prev.linear_interpolate(m_Scale_curr, f))
 	else:
 		# translate
 		if _TestFlags(SF_TRANSLATE):
 			set_position(m_Pos_prev.linear_interpolate(m_Pos_curr, f))
-	
+
 		# rotate
 		if _TestFlags(SF_ROTATE):
 			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
 			set_rotation(r)
-	
+
 		if _TestFlags(SF_SCALE):
 			set_scale(m_Scale_prev.linear_interpolate(m_Scale_curr, f))
-	
+
 	pass
-	
+
+
 func _physics_process(_delta):
 	# take care of the special case where multiple physics ticks
 	# occur before a frame .. the data must flow!
 	if _TestFlags(SF_DIRTY):
 		_RefreshTransform()
-	
+
 	_SetFlags(SF_DIRTY)
 	pass
 
-func _LerpAngle(var from : float, var to : float, var weight : float)->float:
+
+func _LerpAngle(from: float, to: float, weight: float) -> float:
 	return from + _ShortAngleDist(from, to) * weight
 
-func _ShortAngleDist(var from : float, var to : float)->float:
-	var max_angle : float = 2 * PI
-	var diff : float = fmod(to-from, max_angle)
+
+func _ShortAngleDist(from: float, to: float) -> float:
+	var max_angle: float = 2 * PI
+	var diff: float = fmod(to - from, max_angle)
 	return fmod(2.0 * diff, max_angle) - diff
 
-func _SetFlags(var f):
+
+func _SetFlags(f):
 	flags |= f
-	
-func _ClearFlags(var f):
+
+
+func _ClearFlags(f):
 	flags &= ~f
-	
-func _TestFlags(var f):
+
+
+func _TestFlags(f):
 	return (flags & f) == f
 
-func _ChangeFlags(var f, var bSet):
+
+func _ChangeFlags(f, bSet):
 	if bSet:
 		_SetFlags(f)
 	else:

--- a/addons/smoothing/smoothing_plugin.gd
+++ b/addons/smoothing/smoothing_plugin.gd
@@ -1,12 +1,14 @@
 tool
 extends EditorPlugin
 
+
 func _enter_tree():
 	# Initialization of the plugin goes here
 	# Add the new type with a name, a parent type, a script and an icon
 	add_custom_type("Smoothing", "Spatial", preload("smoothing.gd"), preload("smoothing.png"))
 	add_custom_type("Smoothing2D", "Node2D", preload("smoothing_2d.gd"), preload("smoothing_2d.png"))
 	pass
+
 
 func _exit_tree():
 	# Clean-up of the plugin goes here


### PR DESCRIPTION
This makes code follow the GDScript style guide. Line wrapping was disabled since it can cause syntax errors.

gdformat is part of https://github.com/Scony/godot-gdscript-toolkit.