### PR TITLE
Switch from export_enum to export_flags

### DIFF
--- a/addons/smoothing/smoothing.gd
+++ b/addons/smoothing/smoothing.gd
@@ -40,7 +40,7 @@ const SF_BASIS = 1 << 2
 const SF_SLERP = 1 << 3
 const SF_INVISIBLE = 1 << 4
 
-@export_enum(FLAGS, "enabled", "translate", "basis", "slerp") var flags: int = SF_ENABLED | SF_TRANSLATE | SF_BASIS:
+@export_flags("enabled", "translate", "basis", "slerp") var flags: int = SF_ENABLED | SF_TRANSLATE | SF_BASIS:
 	set(v):
 		return _set_flags(v)
 	get:

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -48,7 +48,7 @@ const SF_GLOBAL_OUT = 1 << 5
 const SF_INVISIBLE = 1 << 6
 
 
-@export_enum(FLAGS, "enabled", "translate", "rotate", "scale", "global in", "global out") var flags: int = SF_ENABLED | SF_TRANSLATE:
+@export_flags("enabled", "translate", "rotate", "scale", "global in", "global out") var flags: int = SF_ENABLED | SF_TRANSLATE:
 	set(v):
 		return _set_flags(v)
 	get:


### PR DESCRIPTION
This fixes a small error in `smoothing.gd` and `smoothing_2d.gd` where it was using `@export_enum(FLAGS)` instead of the newer `@export_flags` syntax.