### PR TITLE
fix: enable y-sort with Smoothing2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Usually transforms propagate from a parent to child. Fixed timestep interpolatio
 
 In your gameplay programming, 99% of the time you would usually be mostly concerned with the position and rotation of the physics rep. Aside a few things like visual effects, the visual rep will follow the physics rep, and you don't need to worry about it. This also means that providing you drive your gameplay using `_physics_process` rather than `_process`, your gameplay will run the same no matter what machine you run it on! Fantastic.
 
-### Note
-The smoothing nodes automatically call `set_as_toplevel()` when in global mode. This ensures that they only follow the selected target, rather than having their transform controlled directly by their parent. The default target to follow will however be the parent node, if a `Target` has not been assigned in the inspector.
-
 ## Usage
 
 ### 3D
@@ -81,15 +78,8 @@ As well as choosing the Target, in the inspector for the Smoothing nodes there a
 
 There is no need for JitterFix (`Project Settings->Physics->Common->Physics Jitter Fix`) when using fixed timestep interpolation, indeed it may interfere with getting a good result. The addon now enforces this by setting `Engine.set_physics_jitter_fix` to 0 as smoothing nodes are created.
 
-#### Y-Sort in 2D
-In 2D there is a special case if you want to use y-sorting. The `global_out` setting internally calls `set_as_toplevel()` on the node, unfortunately due to some internal quirks of the engine, this is incompatible with y-sorting. But this is possible to workaround.
-To use y-sorting:
-* Switch off `global_out` in the smoothing node.
-* Do not add the smoothing node as a child of the target (e.g. player). Instead add it on a branch where no transform will be applied from the parent (e.g. a child of the root node where the root node has no transform). Then set the target manually, either using the inspector or calling the `set_target()` function.
-* You can still use `global_in`, this does not break the y-sorting.
-
 ### Authors
-Lawnjelly, Calinou
+Lawnjelly, Calinou, Hunterloftis
 
 __This addon is also available as a c++ module (slight differences), see:__
 https://github.com/lawnjelly/godot-smooth

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -107,8 +107,6 @@ func _SetProcessing():
 	set_process(bEnable)
 	set_physics_process(bEnable)
 
-	set_as_top_level(_TestFlags(SF_GLOBAL_OUT))
-
 func _enter_tree():
 	# might have been moved
 	_FindTarget()
@@ -193,23 +191,28 @@ func _process(_delta):
 
 	var f = Engine.get_physics_interpolation_fraction()
 
-	# We can always use local position rather than set_global_position
-	# because even in global mode we are set_as_top_level, and the result
-	# will be the same.
+	if _TestFlags(SF_GLOBAL_OUT):
+		if _TestFlags(SF_TRANSLATE):
+			set_global_position(m_Pos_prev.lerp(m_Pos_curr, f))
 
-	# translate
-	if _TestFlags(SF_TRANSLATE):
-		set_position(m_Pos_prev.lerp(m_Pos_curr, f))
+		if _TestFlags(SF_ROTATE):
+			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
+			set_global_rotation(r)
 
-	# rotate
-	if _TestFlags(SF_ROTATE):
-		var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
-		set_rotation(r)
+		if _TestFlags(SF_SCALE):
+			set_global_scale(m_Scale_prev.lerp(m_Scale_curr, f))
 
-	if _TestFlags(SF_SCALE):
-		set_scale(m_Scale_prev.lerp(m_Scale_curr, f))
+	else:
+		if _TestFlags(SF_TRANSLATE):
+			set_position(m_Pos_prev.lerp(m_Pos_curr, f))
+			
+		if _TestFlags(SF_ROTATE):
+			var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
+			set_rotation(r)
 
-	pass
+		if _TestFlags(SF_SCALE):
+			set_scale(m_Scale_prev.lerp(m_Scale_curr, f))
+	
 
 
 func _physics_process(_delta):


### PR DESCRIPTION
Resolves https://github.com/lawnjelly/smoothing-addon/issues/31

I was glad to see someone had already written a lovely timestep interpolation addon - thanks for publishing this. I found that I couldn't integrate Smoothing2D into my 2D Godot 4 project, however, because:

1. I rely on y-sorted 2D rendering and
2. The structure of my game relies on several physics bodies, like Character2Ds, as scene roots

It would have taken a fair amount of work to split all the visuals of the physics entities into siblings, rather than children, as currently recommended to work around the addon's incompatibility with y-sort. It also would have made the game's structure more complicated to work on.

With this change, the addon becomes compatible with y-sort without users needing to change node trees.