### PR TITLE
Revert toplevel, simplify 2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# smoothing-addon v 1.1.1
+# smoothing-addon v 1.2
 Fixed timestep interpolation gdscript addon for Godot 3.2 (and later versions)
 
 If you were wondering how to use that new function `Engine.get_physics_interpolation_fraction()` in 3.2, feel free to use this as is, or to get ideas from for your own version. 
@@ -31,7 +31,7 @@ Usually transforms propagate from a parent to child. Fixed timestep interpolatio
 In your gameplay programming, 99% of the time you would usually be mostly concerned with the position and rotation of the physics rep. Aside a few things like visual effects, the visual rep will follow the physics rep, and you don't need to worry about it. This also means that providing you drive your gameplay using `_physics_process` rather than `_process`, your gameplay will run the same no matter what machine you run it on! Fantastic.
 
 ### Note
-The smoothing nodes automatically call `set_as_toplevel()` when in global mode. This ensures that they only follow the selected target, rather than having their transform controlled directly by their parent. The default target to follow will however be the parent node, if a `Target` has not been assigned in the inspector.
+The 3D smoothing node automatically calls `set_as_toplevel()` when in global mode. This ensures that it only follows the selected target, rather than having the transform controlled directly by the parent. The default target to follow will however be the parent node, if a `Target` has not been assigned in the inspector.
 
 ## Usage
 
@@ -63,13 +63,10 @@ As well as choosing the Target, in the inspector for the Smoothing nodes there a
 
 #### 2D
 1. enabled - as above
-2. translate - as above
-3. rotate - interpolation of the node angle
-4. scale - interpolation of the node scale (x and y)
 5. global in - will read the global transform of the target instead of local
 6. global out - will set the global transform of the smoothing node instead of local
 
-(Local mode may be more efficient but you must understand the difference between local and global transforms. Additionally you can turn off rotate and scale if not using them, for increased efficiency.)
+(Local mode may be more efficient but you must understand the difference between local and global transforms.)
 
 ### Notes
 
@@ -80,13 +77,6 @@ As well as choosing the Target, in the inspector for the Smoothing nodes there a
 * In order to prevent an unneeded extra delay of one tick, it is important that smoothing nodes are processed _AFTER_ target nodes. This should now be automatically taken care as the addon internally uses `process_priority` to achieve this. Previously we required smoothing nodes to be placed lower in the scene tree than the target. This should hopefully no longer be the case.
 
 There is no need for JitterFix (`Project Settings->Physics->Common->Physics Jitter Fix`) when using fixed timestep interpolation, indeed it may interfere with getting a good result. The addon now enforces this by setting `Engine.set_physics_jitter_fix` to 0 as smoothing nodes are created.
-
-#### Y-Sort in 2D
-In 2D there is a special case if you want to use y-sorting. The `global_out` setting internally calls `set_as_toplevel()` on the node, unfortunately due to some internal quirks of the engine, this is incompatible with y-sorting. But this is possible to workaround.
-To use y-sorting:
-* Switch off `global_out` in the smoothing node.
-* Do not add the smoothing node as a child of the target (e.g. player). Instead add it on a branch where no transform will be applied from the parent (e.g. a child of the root node where the root node has no transform). Then set the target manually, either using the inspector or calling the `set_target()` function.
-* You can still use `global_in`, this does not break the y-sorting.
 
 ### Authors
 Lawnjelly, Calinou

--- a/Root.tscn
+++ b/Root.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://addons/smoothing/smoothing.gd" type="Script" id=1]
 [ext_resource path="res://addons/smoothing/smoothing.png" type="Texture" id=2]
@@ -8,6 +8,8 @@
 [ext_resource path="res://Target2D.gd" type="Script" id=6]
 [ext_resource path="res://Root.gd" type="Script" id=7]
 [ext_resource path="res://addons/smoothing/smoothing_2d.png" type="Texture" id=8]
+[ext_resource path="res://smooth_icon.png" type="Texture" id=9]
+[ext_resource path="res://Target2D_flipped.gd" type="Script" id=10]
 
 [sub_resource type="CubeMesh" id=3]
 
@@ -41,9 +43,19 @@ script = ExtResource( 4 )
 __meta__ = {
 "_editor_icon": ExtResource( 8 )
 }
+flags = 63
 
 [node name="Sprite_smoothed" type="Sprite" parent="Example2D/Target2D/Smoothing2D"]
 texture = ExtResource( 5 )
+
+[node name="Target2D_flipped" type="Node2D" parent="Example2D"]
+script = ExtResource( 10 )
+
+[node name="Smoothing2D" type="Node2D" parent="Example2D/Target2D_flipped"]
+script = ExtResource( 4 )
+
+[node name="Sprite" type="Sprite" parent="Example2D/Target2D_flipped/Smoothing2D"]
+texture = ExtResource( 9 )
 
 [node name="Example3D" type="Spatial" parent="."]
 

--- a/Target2D_flipped.gd
+++ b/Target2D_flipped.gd
@@ -1,0 +1,26 @@
+extends Node2D
+
+var _x = 0
+var _right = true
+
+func _ready():
+	position = Vector2(200, 100)
+	set_scale(Vector2(-1, 1))
+	
+
+func _physics_process(delta):
+	
+	if _right:
+		_x += 100
+		if _x >= 800:
+			_right = false
+			set_scale(Vector2(1, 1))
+	else:
+		_x -= 100
+		if _x <= 200:
+			_right = true
+			set_scale(Vector2(-1, 1))
+	
+	position.x = _x
+	
+	pass

--- a/addons/smoothing/plugin.cfg
+++ b/addons/smoothing/plugin.cfg
@@ -3,5 +3,5 @@
 name="Smoothing"
 description="Smoothing nodes for fixed timestep interpolation."
 author="Lawnjelly"
-version="1.0.3"
+version="1.2"
 script="smoothing_plugin.gd"

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -23,25 +23,17 @@ extends Node2D
 export (NodePath) var target: NodePath setget set_target, get_target
 
 var _m_Target: Node2D
+var _m_Flip: bool = false
 
-var m_Pos_curr: Vector2 = Vector2()
-var m_Pos_prev: Vector2 = Vector2()
-
-var m_Angle_curr: float
-var m_Angle_prev: float
-
-var m_Scale_curr: Vector2 = Vector2()
-var m_Scale_prev: Vector2 = Vector2()
+var _m_Trans_curr: Transform2D = Transform2D()
+var _m_Trans_prev: Transform2D = Transform2D()
 
 const SF_ENABLED = 1 << 0
-const SF_TRANSLATE = 1 << 1
-const SF_ROTATE = 1 << 2
-const SF_SCALE = 1 << 3
-const SF_GLOBAL_IN = 1 << 4
-const SF_GLOBAL_OUT = 1 << 5
-const SF_INVISIBLE = 1 << 6
+const SF_GLOBAL_IN = 1 << 1
+const SF_GLOBAL_OUT = 1 << 2
+const SF_INVISIBLE = 1 << 3
 
-export (int, FLAGS, "enabled", "translate", "rotate", "scale", "global in", "global out") var flags: int = SF_ENABLED | SF_TRANSLATE | SF_ROTATE | SF_SCALE | SF_GLOBAL_IN | SF_GLOBAL_OUT setget _set_flags, _get_flags
+export (int, FLAGS, "enabled", "global in", "global out") var flags: int = SF_ENABLED | SF_GLOBAL_IN | SF_GLOBAL_OUT setget _set_flags, _get_flags
 
 ##########################################################################################
 # USER FUNCS
@@ -50,20 +42,12 @@ export (int, FLAGS, "enabled", "translate", "rotate", "scale", "global in", "glo
 # call this on e.g. starting a level, AFTER moving the target
 # so we can update both the previous and current values
 func teleport():
-	var temp_flags = flags
-	_SetFlags(SF_TRANSLATE | SF_ROTATE | SF_SCALE)
 
 	_RefreshTransform()
-	m_Pos_prev = m_Pos_curr
-	m_Angle_prev = m_Angle_curr
-	m_Scale_prev = m_Scale_curr
+	_m_Trans_prev = _m_Trans_curr
 
 	# call frame upate to make sure all components of the node are set
 	_process(0)
-
-	# get back the old flags
-	flags = temp_flags
-
 
 func set_enabled(bEnable: bool):
 	_ChangeFlags(SF_ENABLED, bEnable)
@@ -78,8 +62,6 @@ func is_enabled():
 
 
 func _ready():
-	m_Angle_curr = 0
-	m_Angle_prev = 0
 	set_process_priority(100)
 	Engine.set_physics_jitter_fix(0.0)
 
@@ -111,8 +93,6 @@ func _SetProcessing():
 
 	set_process(bEnable)
 	set_physics_process(bEnable)
-	
-	set_as_toplevel(_TestFlags(SF_GLOBAL_OUT))
 
 
 func _enter_tree():
@@ -133,30 +113,16 @@ func _RefreshTransform():
 	if _HasTarget() == false:
 		return
 
+	_m_Trans_prev = _m_Trans_curr
+	
 	if _TestFlags(SF_GLOBAL_IN):
-		if _TestFlags(SF_TRANSLATE):
-			m_Pos_prev = m_Pos_curr
-			m_Pos_curr = _m_Target.get_global_position()
-
-		if _TestFlags(SF_ROTATE):
-			m_Angle_prev = m_Angle_curr
-			m_Angle_curr = _m_Target.get_global_rotation()
-
-		if _TestFlags(SF_SCALE):
-			m_Scale_prev = m_Scale_curr
-			m_Scale_curr = _m_Target.get_global_scale()
+		_m_Trans_curr = _m_Target.get_global_transform()
 	else:
-		if _TestFlags(SF_TRANSLATE):
-			m_Pos_prev = m_Pos_curr
-			m_Pos_curr = _m_Target.get_position()
-
-		if _TestFlags(SF_ROTATE):
-			m_Angle_prev = m_Angle_curr
-			m_Angle_curr = _m_Target.get_rotation()
-
-		if _TestFlags(SF_SCALE):
-			m_Scale_prev = m_Scale_curr
-			m_Scale_curr = _m_Target.get_scale()
+		_m_Trans_curr = _m_Target.get_transform()
+		
+	_m_Flip = false
+	if (_m_Trans_prev.determinant() < 0) != (_m_Trans_curr.determinant() < 0):
+		_m_Flip = true
 
 func _FindTarget():
 	_m_Target = null
@@ -200,37 +166,23 @@ func _process(_delta):
 
 	var f = Engine.get_physics_interpolation_fraction()
 
-	# We can always use local position rather than set_global_position
-	# because even in global mode we are set_as_top_level, and the result
-	# will be the same.
-	
-	# translate
-	if _TestFlags(SF_TRANSLATE):
-		set_position(m_Pos_prev.linear_interpolate(m_Pos_curr, f))
+	var tr = Transform2D()
+	tr.origin = lerp(_m_Trans_prev.origin, _m_Trans_curr.origin, f)
+	tr.x = lerp(_m_Trans_prev.x, _m_Trans_curr.x, f)
+	tr.y = lerp(_m_Trans_prev.y, _m_Trans_curr.y, f)
 
-	# rotate
-	if _TestFlags(SF_ROTATE):
-		var r = _LerpAngle(m_Angle_prev, m_Angle_curr, f)
-		set_rotation(r)
-
-	if _TestFlags(SF_SCALE):
-		set_scale(m_Scale_prev.linear_interpolate(m_Scale_curr, f))
-
-	pass
-
+	# When a sprite flip is detected, turn off interpolation for that tick.
+	if _m_Flip:
+		tr = _m_Trans_curr
+		
+	if _TestFlags(SF_GLOBAL_OUT):
+		set_global_transform(tr)
+	else:
+		set_transform(tr)
 
 func _physics_process(_delta):
 	_RefreshTransform()
 
-
-func _LerpAngle(from: float, to: float, weight: float) -> float:
-	return from + _ShortAngleDist(from, to) * weight
-
-
-func _ShortAngleDist(from: float, to: float) -> float:
-	var max_angle: float = 2 * PI
-	var diff: float = fmod(to - from, max_angle)
-	return fmod(2.0 * diff, max_angle) - diff
 
 
 func _SetFlags(f):


### PR DESCRIPTION
The toplevel approach in 2D was causing problems with y-sorting and propagating visibility changes. Revert to allowing global transform output with regular inheritance in the scene tree. Simplify to basis lerping to prevent problems with global transform.

## Notes
* This is mostly reverting the `toplevel` approach tried this year which has caused a lot of problems:
1) Visibility was not inherited - if you made the parent object invisible, the smoothed version was staying visible
2) As a result of this, processing was not getting throttled down for hidden objects
3) Y sorting was broken.
* There are no changes to 3D.