### PR TITLE
Add optional toplevel mode for 2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# smoothing-addon v 1.2
+# smoothing-addon v 1.2.1
 Fixed timestep interpolation gdscript addon for Godot 4.x (and later versions)
 
 If you were wondering how to use that new function `Engine.get_physics_interpolation_fraction()` in 3.2, feel free to use this as is, or to get ideas from for your own version. 
@@ -44,6 +44,10 @@ The 3D smoothing node automatically calls `set_as_toplevel()` when in global mod
 
 ### 2D
 The procedure for 2D is pretty much the same as with 3D except you would be using a node derived from Node2D as the physics rep (target) and the 'Smoothing2D' node should be used instead of 'Smoothing'.
+
+In 2D, for legacy support, the smoothing node can be set to `toplevel` if the property flag is enabled (this defaults to disabled). `toplevel` enables the transform of the smoothing node to be specified in true global space (which is more stable, and may play better with GPU snapping), however has two downsides:
+1. Parent node visibility is not automatically propagated to `toplevel` nodes, thus you have to explicitly hide the smoothing node, rather than rely on hiding just the parent node.
+2. Y-sorting does not work correctly for `toplevel` nodes.
 
 ### Following targets that are not the parent node
 Additionally the smoothing node has the ability to follow targets that are not parent nodes. You can do this by assigning a `Target` in the inspector panel for the Smoothing node.

--- a/addons/smoothing/plugin.cfg
+++ b/addons/smoothing/plugin.cfg
@@ -3,5 +3,5 @@
 name="Smoothing"
 description="Smoothing nodes for fixed timestep interpolation."
 author="Lawnjelly"
-version="1.2"
+version="1.2.1"
 script="smoothing_plugin.gd"

--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -39,9 +39,10 @@ var _m_Trans_prev: Transform2D = Transform2D()
 const SF_ENABLED = 1 << 0
 const SF_GLOBAL_IN = 1 << 1
 const SF_GLOBAL_OUT = 1 << 2
-const SF_INVISIBLE = 1 << 3
+const SF_TOP_LEVEL = 1 << 3
+const SF_INVISIBLE = 1 << 4
 
-@export_flags("enabled", "global in", "global out") var flags: int = SF_ENABLED | SF_GLOBAL_IN | SF_GLOBAL_OUT:
+@export_flags("enabled", "global in", "global out", "top level") var flags: int = SF_ENABLED | SF_GLOBAL_IN | SF_GLOBAL_OUT:
 	set(v):
 		flags = v
 		# we may have enabled or disabled
@@ -78,6 +79,7 @@ func is_enabled():
 func _ready():
 	set_process_priority(100)
 	Engine.set_physics_jitter_fix(0.0)
+	set_as_top_level(_TestFlags(SF_TOP_LEVEL))
 
 
 func _SetProcessing():
@@ -87,6 +89,7 @@ func _SetProcessing():
 
 	set_process(bEnable)
 	set_physics_process(bEnable)
+	set_as_top_level(_TestFlags(SF_TOP_LEVEL))
 
 
 func _enter_tree():
@@ -180,7 +183,7 @@ func _process(_delta):
 	if _m_Flip:
 		tr = _m_Trans_curr
 
-	if _TestFlags(SF_GLOBAL_OUT):
+	if _TestFlags(SF_GLOBAL_OUT) and not _TestFlags(SF_TOP_LEVEL):
 		set_global_transform(tr)
 	else:
 		set_transform(tr)


### PR DESCRIPTION
May work better with GPU snapping.

Fixes #42

## Notes
* Included for legacy use, but in most cases, not recommended.