### PR TITLE
Simplify 2D interpolation callbacks

### DIFF
--- a/addons/smoothing/smoothing_2d.gd
+++ b/addons/smoothing/smoothing_2d.gd
@@ -174,10 +174,7 @@ func _HasTarget() -> bool:
 func _process(_delta):
 	var f = Engine.get_physics_interpolation_fraction()
 
-	var tr = Transform2D()
-	tr.origin = lerp(_m_Trans_prev.origin, _m_Trans_curr.origin, f)
-	tr.x = lerp(_m_Trans_prev.x, _m_Trans_curr.x, f)
-	tr.y = lerp(_m_Trans_prev.y, _m_Trans_curr.y, f)
+	var tr = _m_Trans_prev.interpolate_with(_m_Trans_curr, f)
 
 	# When a sprite flip is detected, turn off interpolation for that tick.
 	if _m_Flip:


### PR DESCRIPTION
The Transform types since 4.0 have the `interpolate_with()` function, which can be used to simplify those lines. This PR does this for 2D.

Something similar can be done to 3D (through `Transform3D.interpolate_with()`, but doing so would enforce translate and basis method without slerp;